### PR TITLE
Maps Parsing and PM reading Implemented

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ modules.order
 Module.symvers
 Mkfile.old
 dkms.conf
+
+# Vscode debug folder
+.vscode

--- a/vpmap.c
+++ b/vpmap.c
@@ -1,6 +1,7 @@
 // vpmap.c: initial checkin
 
 #include <stdio.h>
+#include <stdint.h>
 
 // The following two structs use bitfields to enable easier parsing of
 // the data provided in /proc/<pid>/maps that will be a 64-bit number

--- a/vpmap.c
+++ b/vpmap.c
@@ -1,7 +1,13 @@
 // vpmap.c: initial checkin
 
+#define PAGE_SIZE sysconf(_SC_PAGE_SIZE)
+
 #include <stdio.h>
+#include <stdlib.h>
 #include <stdint.h>
+#include <string.h>
+#include <fcntl.h>
+#include <unistd.h>
 
 // The following two structs use bitfields to enable easier parsing of
 // the data provided in /proc/<pid>/maps that will be a 64-bit number
@@ -11,6 +17,18 @@
 // https://docs.kernel.org/admin-guide/mm/pagemap.html
 
 // NOTE: may move the structs to a header file at some point
+
+typedef struct {
+  uint64_t start_addr;      // The first address in the range.
+  uint64_t end_addr;        // The last address in the range.
+  char mode[5];             // The mode in which the file is opened (rwxp).
+  uint64_t offset;          // The start offset in bytes within the file that is mapped.
+  uint32_t major_id;        // Together with minor_id represents the device that holds the file.
+  uint32_t minor_id;        // 08:30 for the device that holds the root filesystem, 00:00 for non-file mappings.
+  uint64_t inode_id;        // ID of a struct containing some filesystem metadata.
+  char *path;               // The path to the file, or something like [heap] or [stack]
+                            //   Must be freed
+} maps_entry_t;
 
 // map entry which is present in memory (not swapped out)
 typedef struct {
@@ -43,8 +61,133 @@ typedef struct {
 typedef union {
   entry_present_t present;
   entry_swapped_t swapped;
-} map_entry_t;
+} pm_entry_t;
+
+// NOTE: These functions should probably be moved along with structs above.
+
+/**
+ * @brief Opens pagemap and maps for the given PID.
+ * @param pid A string containing the PID number.
+ * @param maps_fd A pointer to an integer to contain the maps file descriptor.
+ * @param pm_fd A pointer to an integer to contain the pagemap file descriptor.
+*/
+void proc_open(char *pid, int *maps_fd, int *pm_fd)
+{
+  char maps_path[strlen(pid) + 11];
+  char pm_path[strlen(pid) + 14];
+  sprintf(maps_path, "/proc/%s/maps", pid);
+  sprintf(pm_path, "/proc/%s/pagemap", pid);
+
+	*maps_fd = open(maps_path, O_RDONLY);
+  *pm_fd = open(pm_path, O_RDONLY);
+
+	if (*maps_fd < 0) {
+		perror(maps_path);
+		exit(EXIT_FAILURE);
+	}
+
+  if (*pm_fd < 0) {
+    perror(pm_path);
+    exit(EXIT_FAILURE);
+  }
+}
+
+/**
+ * @brief Reads one entry of pagemap.
+ * @param pm_fd The file descriptor for the pagemap.
+ * @param buf The buffer to be written to.
+ * @param vaddr The virtual address to be read from the pagemap.
+*/
+void pmread(int pm_fd, pm_entry_t *buf, uint64_t vaddr)
+{
+  long bytes = pread(pm_fd, buf, 8, (off_t)(vaddr / PAGE_SIZE * 8));
+  
+  if (bytes < 0)
+    exit(EXIT_FAILURE);
+}
+
+/**
+ * @brief Prints the physical address of a pagemap entry.
+ * Can also print NOT PRESENT, or SWAPPED.
+ * @param entry A pagemap entry struct that has already been filled by pmread.
+ * @param vaddr The virtual adress of the
+*/
+void print_phys_addr(const pm_entry_t *entry)
+{
+  if (!entry->present.present) {
+    printf(" | ENTRY: %016lx | NOT PRESENT\n", *(uint64_t *)entry);
+    return;
+  }
+
+  if (entry->present.swapped) {
+    printf(" | ENTRY: %016lx | SWAPPED\n", *(uint64_t *)entry);
+    return;
+  }
+
+  uint64_t phys_addr = entry->present.pfn * PAGE_SIZE;
+  printf(" | ENTRY: %016lx | PFN: %lx\n", *(uint64_t *)entry, phys_addr);
+}
+
+/**
+ * @brief Parses one line of maps into a maps_entry buffer struct.
+ * @param entry A maps_entry struct that will be written to.
+ * @param maps The file descriptor for maps.
+*/
+void maps_parseln(maps_entry_t *entry, FILE **maps)
+{
+  // Assumes that an entry is less than 512 bytes long, this could be fixed.
+  char buff[512];
+  char pathbuff[512];
+  fgets(buff, 512, *maps);
+  if (strlen(buff) < 73) {
+    sscanf(buff, "%lx-%lx %s %lx %x:%x %lx",
+      &entry->start_addr, &entry->end_addr, entry->mode, &entry->offset,
+      &entry->major_id, &entry->minor_id, &entry->inode_id);
+    pathbuff[0] = '\0';
+  } else {
+    sscanf(buff, "%lx-%lx %s %lx %x:%x %lx %s",
+      &entry->start_addr, &entry->end_addr, entry->mode, &entry->offset,
+      &entry->major_id, &entry->minor_id, &entry->inode_id, pathbuff);
+  }
+  
+  entry->path = malloc(strlen(pathbuff));
+  strcpy(entry->path, pathbuff);
+};
+
+/**
+ * @brief Walks through the maps file and prints the physical address number
+ * in a table.
+ * @param maps_fd The file descriptor for maps.
+ * @param pm_fd The file descirptor for the pagemap.
+*/
+void maps_parse(int maps_fd, int pm_fd)
+{
+  FILE *maps = fdopen(maps_fd, "r");
+  maps_entry_t maps_entry;
+  pm_entry_t pm_entry;
+  uint64_t phys_addr;
+
+  char maps_buff[512];
+
+  maps_parseln(&maps_entry, &maps);
+  while (!feof(maps)) {
+    sprintf(maps_buff, "%lx-%lx %s %08lx %02x:%02x %lx %s",
+      maps_entry.start_addr, maps_entry.end_addr, maps_entry.mode,
+      maps_entry.offset, maps_entry.major_id, maps_entry.minor_id,
+      maps_entry.inode_id, maps_entry.path);
+    printf("%-115s", maps_buff);
+
+    pmread(pm_fd, &pm_entry, maps_entry.start_addr);
+    print_phys_addr(&pm_entry);
+
+    free(maps_entry.path);
+    maps_parseln(&maps_entry, &maps);
+  }
+};
 
 int main(int argc, char *argv[]){
+  int maps_fd, pm_fd;
+  proc_open(argv[1], &maps_fd, &pm_fd);
+  maps_parse(maps_fd, pm_fd);
   return 0;
 }


### PR DESCRIPTION
Running the program with `sudo ./vpmap.out <pid>` now regurgitates /proc/pid/maps and prints the 64 bit entry related to the first virtual address of each line of maps as well as the PFN of that entry. (Works for "self" as well).

I added a new struct, maps_entry_t, which stores the data that is held in one entry of maps (as the name would imply). Using scanf, I read maps line by line, and extract the information from it. Currently, most of the information from maps is just printed right back onto the screen as a sort of proof of concept. I did however, write a function that uses pread to take the starting virtual address and read an entry and a PFN from pagemap.

Currently, my code doesn't do much with swapped pages (it only prints out SWAPPED or NOT-PRESENT) functionality should definitely be expanded here.

As a final (but rather important note), the program actually returns NOT-PRESENT for some entries that appear in maps. I can't really figure out why this is the case, but it seems to be consistent (e.g. [stack] and [vvar] always show up as not present). Interestingly enough (at least from my testing), the two example programs also showed that those entries were not present. Maybe I made a mistake here... I can't really tell.