### PR TITLE
Fixed Signoff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Backup files
+*~
+
 # Prerequisites
 *.d
 

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ modules.order
 Module.symvers
 Mkfile.old
 dkms.conf
+
+# Vscode debug folder
+.vscode

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ Code and Documentation produced by the Virtual Memory subbroup
 
 ## Manifest
 
+| File        | Description                                                          |
+|-------------| -------------------------------------------------------------------- |
 | vpmap.c     | New program to map ranges of virtual addresses to physical locations |
 | ref_code1.c | Reference implementation on converting memory to physical addresses  |
 | ref_code2.c | Reference implementation on converting memory to physical addresses  |

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # virtmem
 Code and Documentation produced by the Virtual Memory subbroup
+
+## Manifest
+
+| vpmap.c     | New program to map ranges of virtual addresses to physical locations |
+| ref_code1.c | Reference implementation on converting memory to physical addresses  |
+| ref_code2.c | Reference implementation on converting memory to physical addresses  |
+
+## References
+- [Kernel Docs on /proc FS Memory Maps](https://docs.kernel.org/admin-guide/mm/pagemap.html)
+- [Blog Post on Related Program](https://fivelinesofcode.blogspot.com/2014/03/how-to-translate-virtual-to-physical.html)
+- [Stack Overflow Post on Related Program](https://stackoverflow.com/questions/5748492/is-there-any-api-for-determining-the-physical-address-from-virtual-address-in-li)

--- a/ref_code1.c
+++ b/ref_code1.c
@@ -1,0 +1,102 @@
+// Originally from:
+// https://fivelinesofcode.blogspot.com/2014/03/how-to-translate-virtual-to-physical.html
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <assert.h>
+#include <errno.h>
+#include <stdint.h>
+#include <string.h>
+
+#define PAGEMAP_ENTRY 8
+#define GET_BIT(X,Y) (X & ((uint64_t)1<<Y)) >> Y
+#define GET_PFN(X) X & 0x7FFFFFFFFFFFFF
+
+const int __endian_bit = 1;
+#define is_bigendian() ( (*(char*)&__endian_bit) == 0 )
+
+int i, c, pid, status;
+unsigned long virt_addr; 
+uint64_t read_val, file_offset;
+char path_buf [0x100] = {};
+FILE * f;
+char *end;
+
+int read_pagemap(char * path_buf, unsigned long virt_addr);
+
+int main(int argc, char ** argv){
+   //printf("%lu\n", GET_BIT(0xA680000000000000, 63));
+   //return 0;
+   if(argc!=3){
+      printf("Argument number is not correct!\n pagemap PID VIRTUAL_ADDRESS\n");
+      return -1;
+   }
+   if(!memcmp(argv[1],"self",sizeof("self"))){
+      sprintf(path_buf, "/proc/self/pagemap");
+      pid = -1;
+   }
+   else{
+         pid = strtol(argv[1],&end, 10);
+         if (end == argv[1] || *end != '\0' || pid<=0){ 
+            printf("PID must be a positive number or 'self'\n");
+            return -1;
+            }
+       }
+   virt_addr = strtol(argv[2], NULL, 16);
+   if(pid!=-1)
+      sprintf(path_buf, "/proc/%u/pagemap", pid);
+   
+   read_pagemap(path_buf, virt_addr);
+   return 0;
+}
+
+int read_pagemap(char * path_buf, unsigned long virt_addr){
+   printf("Big endian? %d\n", is_bigendian());
+   f = fopen(path_buf, "rb");
+   if(!f){
+      printf("Error! Cannot open %s\n", path_buf);
+      return -1;
+   }
+   
+   //Shifting by virt-addr-offset number of bytes
+   //and multiplying by the size of an address (the size of an entry in pagemap file)
+   file_offset = virt_addr / getpagesize() * PAGEMAP_ENTRY;
+   printf("Vaddr: 0x%lx, Page_size: %d, Entry_size: %d\n", virt_addr, getpagesize(), PAGEMAP_ENTRY);
+   printf("Reading %s at 0x%llx\n", path_buf, (unsigned long long) file_offset);
+   status = fseek(f, file_offset, SEEK_SET);
+   if(status){
+      perror("Failed to do fseek!");
+      return -1;
+   }
+   errno = 0;
+   read_val = 0;
+   unsigned char c_buf[PAGEMAP_ENTRY];
+   for(i=0; i < PAGEMAP_ENTRY; i++){
+      c = getc(f);
+      if(c==EOF){
+         printf("\nReached end of the file\n");
+         return 0;
+      }
+      if(is_bigendian())
+           c_buf[i] = c;
+      else
+           c_buf[PAGEMAP_ENTRY - i - 1] = c;
+      printf("[%d]0x%x ", i, c);
+   }
+   for(i=0; i < PAGEMAP_ENTRY; i++){
+      //printf("%d ",c_buf[i]);
+      read_val = (read_val << 8) + c_buf[i];
+   }
+   printf("\n");
+   printf("Result: 0x%llx\n", (unsigned long long) read_val);
+   //if(GET_BIT(read_val, 63))
+   if(GET_BIT(read_val, 63))
+      printf("PFN: 0x%llx\n",(unsigned long long) GET_PFN(read_val));
+   else
+      printf("Page not present\n");
+   if(GET_BIT(read_val, 62))
+      printf("Page swapped\n");
+   fclose(f);
+   return 0;
+}

--- a/ref_code2.c
+++ b/ref_code2.c
@@ -1,0 +1,101 @@
+// Originally from
+// https://stackoverflow.com/questions/5748492/is-there-any-api-for-determining-the-physical-address-from-virtual-address-in-li
+
+#define _XOPEN_SOURCE 700
+#include <fcntl.h> /* open */
+#include <stdint.h> /* uint64_t  */
+#include <stdio.h> /* printf */
+#include <stdlib.h> /* size_t */
+#include <unistd.h> /* pread, sysconf */
+
+typedef struct {
+    uint64_t pfn : 55;
+    unsigned int soft_dirty : 1;
+    unsigned int file_page : 1;
+    unsigned int swapped : 1;
+    unsigned int present : 1;
+} PagemapEntry;
+// This struct can be improved as with the bitfield technique, one can
+// read the 64-bit number directly into this struct and gain access to
+// each piece of data using the name indicated, just need to all the
+// fields described in the docs below
+// 
+//  https://docs.kernel.org/admin-guide/mm/pagemap.html
+
+
+/* Parse the pagemap entry for the given virtual address.
+ *
+ * @param[out] entry      the parsed entry
+ * @param[in]  pagemap_fd file descriptor to an open /proc/pid/pagemap file
+ * @param[in]  vaddr      virtual address to get entry for
+ * @return 0 for success, 1 for failure
+ */
+int pagemap_get_entry(PagemapEntry *entry, int pagemap_fd, uintptr_t vaddr)
+{
+    size_t nread;
+    ssize_t ret;
+    uint64_t data;
+    uintptr_t vpn;
+
+    vpn = vaddr / sysconf(_SC_PAGE_SIZE);
+    nread = 0;
+    while (nread < sizeof(data)) {
+        ret = pread(pagemap_fd, ((uint8_t*)&data) + nread, sizeof(data) - nread,
+                vpn * sizeof(data) + nread);
+        nread += ret;
+        if (ret <= 0) {
+            return 1;
+        }
+    }
+    entry->pfn = data & (((uint64_t)1 << 55) - 1);
+    entry->soft_dirty = (data >> 55) & 1;
+    entry->file_page = (data >> 61) & 1;
+    entry->swapped = (data >> 62) & 1;
+    entry->present = (data >> 63) & 1;
+    return 0;
+}
+
+/* Convert the given virtual address to physical using /proc/PID/pagemap.
+ *
+ * @param[out] paddr physical address
+ * @param[in]  pid   process to convert for
+ * @param[in] vaddr virtual address to get entry for
+ * @return 0 for success, 1 for failure
+ */
+int virt_to_phys_user(uintptr_t *paddr, pid_t pid, uintptr_t vaddr)
+{
+    char pagemap_file[BUFSIZ];
+    int pagemap_fd;
+
+    snprintf(pagemap_file, sizeof(pagemap_file), "/proc/%ju/pagemap", (uintmax_t)pid);
+    pagemap_fd = open(pagemap_file, O_RDONLY);
+    if (pagemap_fd < 0) {
+        return 1;
+    }
+    PagemapEntry entry;
+    if (pagemap_get_entry(&entry, pagemap_fd, vaddr)) {
+        return 1;
+    }
+    close(pagemap_fd);
+    *paddr = (entry.pfn * sysconf(_SC_PAGE_SIZE)) + (vaddr % sysconf(_SC_PAGE_SIZE));
+    return 0;
+}
+
+int main(int argc, char **argv)
+{
+    pid_t pid;
+    uintptr_t vaddr, paddr = 0;
+
+    if (argc < 3) {
+        printf("Usage: %s pid vaddr\n", argv[0]);
+        return EXIT_FAILURE;
+    }
+    pid = strtoull(argv[1], NULL, 0);
+    vaddr = strtoull(argv[2], NULL, 0);
+    if (virt_to_phys_user(&paddr, pid, vaddr)) {
+        fprintf(stderr, "error: virt_to_phys_user\n");
+        return EXIT_FAILURE;
+    };
+    printf("0x%jx\n", (uintmax_t)paddr);
+    return EXIT_SUCCESS;
+}

--- a/vpmap.c
+++ b/vpmap.c
@@ -1,6 +1,7 @@
 // vpmap.c: initial checkin
 
 #include <stdio.h>
+#include <stdint.h>
 
 // The following two structs use bitfields to enable easier parsing of
 // the data provided in /proc/<pid>/maps that will be a 64-bit number

--- a/vpmap.c
+++ b/vpmap.c
@@ -1,7 +1,13 @@
 // vpmap.c: initial checkin
 
+#define PAGE_SIZE sysconf(_SC_PAGE_SIZE)
+
 #include <stdio.h>
+#include <stdlib.h>
 #include <stdint.h>
+#include <string.h>
+#include <fcntl.h>
+#include <unistd.h>
 
 // The following two structs use bitfields to enable easier parsing of
 // the data provided in /proc/<pid>/maps that will be a 64-bit number
@@ -11,6 +17,18 @@
 // https://docs.kernel.org/admin-guide/mm/pagemap.html
 
 // NOTE: may move the structs to a header file at some point
+
+typedef struct {
+  uint64_t start_addr;      // The first address in the range.
+  uint64_t end_addr;        // The last address in the range.
+  char mode[5];             // The mode in which the file is opened (rwxp).
+  uint64_t offset;          // The start offset in bytes within the file that is mapped.
+  uint32_t major_id;        // Together with minor_id represents the device that holds the file.
+  uint32_t minor_id;        // 08:30 for the device that holds the root filesystem, 00:00 for non-file mappings.
+  uint64_t inode_id;        // ID of a struct containing some filesystem metadata.
+  char *path;               // The path to the file, or something like [heap] or [stack]
+                            //   Must be freed
+} maps_entry_t;
 
 // map entry which is present in memory (not swapped out)
 typedef struct {
@@ -43,8 +61,133 @@ typedef struct {
 typedef union {
   entry_present_t present;
   entry_swapped_t swapped;
-} map_entry_t;
+} pm_entry_t;
+
+// NOTE: These functions should probably be moved along with structs above.
+
+/**
+ * @brief Opens pagemap and maps for the given PID.
+ * @param pid A string containing the PID number.
+ * @param maps_fd A pointer to an integer to contain the maps file descriptor.
+ * @param pm_fd A pointer to an integer to contain the pagemap file descriptor.
+*/
+void proc_open(char *pid, int *maps_fd, int *pm_fd)
+{
+  char maps_path[strlen(pid) + 11];
+  char pm_path[strlen(pid) + 14];
+  sprintf(maps_path, "/proc/%s/maps", pid);
+  sprintf(pm_path, "/proc/%s/pagemap", pid);
+
+	*maps_fd = open(maps_path, O_RDONLY);
+  *pm_fd = open(pm_path, O_RDONLY);
+
+	if (*maps_fd < 0) {
+		perror(maps_path);
+		exit(EXIT_FAILURE);
+	}
+
+  if (*pm_fd < 0) {
+    perror(pm_path);
+    exit(EXIT_FAILURE);
+  }
+}
+
+/**
+ * @brief Reads one entry of pagemap.
+ * @param pm_fd The file descriptor for the pagemap.
+ * @param buf The buffer to be written to.
+ * @param vaddr The virtual address to be read from the pagemap.
+*/
+void pmread(int pm_fd, pm_entry_t *buf, uint64_t vaddr)
+{
+  long bytes = pread(pm_fd, buf, 8, (off_t)(vaddr / PAGE_SIZE * 8));
+  
+  if (bytes < 0)
+    exit(EXIT_FAILURE);
+}
+
+/**
+ * @brief Prints the physical address of a pagemap entry.
+ * Can also print NOT PRESENT, or SWAPPED.
+ * @param entry A pagemap entry struct that has already been filled by pmread.
+ * @param vaddr The virtual adress of the
+*/
+void print_phys_addr(const pm_entry_t *entry)
+{
+  if (!entry->present.present) {
+    printf(" | ENTRY: %016lx | NOT PRESENT\n", *(uint64_t *)entry);
+    return;
+  }
+
+  if (entry->present.swapped) {
+    printf(" | ENTRY: %016lx | SWAPPED\n", *(uint64_t *)entry);
+    return;
+  }
+
+  uint64_t phys_addr = entry->present.pfn * PAGE_SIZE;
+  printf(" | ENTRY: %016lx | PFN: %lx\n", *(uint64_t *)entry, phys_addr);
+}
+
+/**
+ * @brief Parses one line of maps into a maps_entry buffer struct.
+ * @param entry A maps_entry struct that will be written to.
+ * @param maps The file descriptor for maps.
+*/
+void maps_parseln(maps_entry_t *entry, FILE **maps)
+{
+  // Assumes that an entry is less than 512 bytes long, this could be fixed.
+  char buff[512];
+  char pathbuff[512];
+  fgets(buff, 512, *maps);
+  if (strlen(buff) < 73) {
+    sscanf(buff, "%lx-%lx %s %lx %x:%x %lx",
+      &entry->start_addr, &entry->end_addr, entry->mode, &entry->offset,
+      &entry->major_id, &entry->minor_id, &entry->inode_id);
+    pathbuff[0] = '\0';
+  } else {
+    sscanf(buff, "%lx-%lx %s %lx %x:%x %lx %s",
+      &entry->start_addr, &entry->end_addr, entry->mode, &entry->offset,
+      &entry->major_id, &entry->minor_id, &entry->inode_id, pathbuff);
+  }
+  
+  entry->path = malloc(strlen(pathbuff));
+  strcpy(entry->path, pathbuff);
+};
+
+/**
+ * @brief Walks through the maps file and prints the physical address number
+ * in a table.
+ * @param maps_fd The file descriptor for maps.
+ * @param pm_fd The file descirptor for the pagemap.
+*/
+void maps_parse(int maps_fd, int pm_fd)
+{
+  FILE *maps = fdopen(maps_fd, "r");
+  maps_entry_t maps_entry;
+  pm_entry_t pm_entry;
+  uint64_t phys_addr;
+
+  char maps_buff[512];
+
+  maps_parseln(&maps_entry, &maps);
+  while (!feof(maps)) {
+    sprintf(maps_buff, "%lx-%lx %s %08lx %02x:%02x %lx %s",
+      maps_entry.start_addr, maps_entry.end_addr, maps_entry.mode,
+      maps_entry.offset, maps_entry.major_id, maps_entry.minor_id,
+      maps_entry.inode_id, maps_entry.path);
+    printf("%-115s", maps_buff);
+
+    pmread(pm_fd, &pm_entry, maps_entry.start_addr);
+    print_phys_addr(&pm_entry);
+
+    free(maps_entry.path);
+    maps_parseln(&maps_entry, &maps);
+  }
+};
 
 int main(int argc, char *argv[]){
+  int maps_fd, pm_fd;
+  proc_open(argv[1], &maps_fd, &pm_fd);
+  maps_parse(maps_fd, pm_fd);
   return 0;
 }

--- a/vpmap.c
+++ b/vpmap.c
@@ -1,0 +1,49 @@
+// vpmap.c: initial checkin
+
+#include <stdio.h>
+
+// The following two structs use bitfields to enable easier parsing of
+// the data provided in /proc/<pid>/maps that will be a 64-bit number
+// with bits representing a aspects of the page. The bit layouts are
+// extracted from the kernel docs on the /proc interface to page
+// tables which is here:
+// https://docs.kernel.org/admin-guide/mm/pagemap.html
+
+// NOTE: may move the structs to a header file at some point
+
+// map entry which is present in memory (not swapped out)
+typedef struct {
+  uint64_t pfn     : 55;    // Bits 0-54 page frame number (PFN) if present                             
+  uint32_t dirty   :  1;    // Bit 55 pte is soft-dirty (see Soft-Dirty PTEs)                           
+  uint32_t exclu   :  1;    // Bit 56 page exclusively mapped (since 4.2)                               
+  uint32_t wprot   :  1;    // Bit 57 pte is uffd-wp write-protected (since 5.13) (see Userfaultfd)     
+  uint32_t zeros   :  3;    // Bits 58-60 zero                                                          
+  uint32_t isanon  :  1;    // Bit 61 page is file-page or shared-anon (since 3.5)                      
+  uint32_t swapped :  1;    // Bit 62 page swapped                                                      
+  uint32_t present :  1;    // Bit 63 page present                                                      
+} entry_present_t;
+
+// map entry which is swapped out
+typedef struct {
+  uint32_t swaptyp :  5;    // Bits 0-4 swap type if swapped
+  uint64_t pfn     : 50;    // Bits 5-54 swap offset if swapped
+  uint32_t dirty   :  1;    // Bit 55 pte is soft-dirty (see Soft-Dirty PTEs)                           
+  uint32_t exclu   :  1;    // Bit 56 page exclusively mapped (since 4.2)                               
+  uint32_t wprot   :  1;    // Bit 57 pte is uffd-wp write-protected (since 5.13) (see Userfaultfd)     
+  uint32_t zeros   :  3;    // Bits 58-60 zero                                                          
+  uint32_t isanon  :  1;    // Bit 61 page is file-page or shared-anon (since 3.5)                      
+  uint32_t swapped :  1;    // Bit 62 page swapped                                                      
+  uint32_t present :  1;    // Bit 63 page present                                                      
+} entry_swapped_t;
+
+// union of the two struct types so that one can access via
+// map_entry_t entry;
+// entry.present.pfn == ???;
+typedef union {
+  entry_present_t present;
+  entry_swapped_t swapped;
+} map_entry_t;
+
+int main(int argc, char *argv[]){
+  return 0;
+}


### PR DESCRIPTION
Running the program with `sudo ./vpmap.out <pid>` now regurgitates /proc/pid/maps and prints the 64 bit entry related to the first virtual address of each line of maps as well as the PFN of that entry. (Works for "self" as well).

I added a new struct, maps_entry_t, which stores the data that is held in one entry of maps (as the name would imply). Using scanf, I read maps line by line, and extract the information from it. Currently, most of the information from maps is just printed right back onto the screen as a sort of proof of concept. I did however, write a function that uses pread to take the starting virtual address and read an entry and a PFN from pagemap.

Currently, my code doesn't do much with swapped pages (it only prints out SWAPPED or NOT-PRESENT) functionality should definitely be expanded here.

As a final (but rather important note), the program actually returns NOT-PRESENT for some entries that appear in maps. I can't really figure out why this is the case, but it seems to be consistent (e.g. [stack] and [vvar] always show up as not present). Interestingly enough (at least from my testing), the two example programs also showed that those entries were not present. Maybe I made a mistake here... I can't really tell.